### PR TITLE
Update for OLEDclock.py

### DIFF
--- a/python-examples/OLEDclock.py
+++ b/python-examples/OLEDclock.py
@@ -12,8 +12,6 @@ import gaugette.gpio
 import time
 import sys
 
-ROWS = 32
-
 # Define which GPIO pins the reset (RST) and DC signals on the OLED display are connected to on the
 # Raspberry Pi. The defined pin numbers must use the WiringPi pin numbering scheme.
 RESET_PIN = 15 # WiringPi pin 15 is GPIO14.
@@ -24,20 +22,16 @@ spi_device = 0
 gpio = gaugette.gpio.GPIO()
 spi = gaugette.spi.SPI(spi_bus, spi_device)
 
-print("init")
-led = gaugette.ssd1306.SSD1306(gpio, spi, reset_pin=RESET_PIN, dc_pin=DC_PIN, rows=ROWS, cols=128)
-print("begin")
+led = gaugette.ssd1306.SSD1306(gpio, spi, reset_pin=RESET_PIN, dc_pin=DC_PIN, rows=32, cols=128) # Change rows & cols values depending on your display dimensions.
 led.begin()
-print("clear")
 led.clear_display()
 led.display()
-
 led.invert_display()
 time.sleep(0.5)
 led.normal_display()
 time.sleep(0.5)
 
-offset = 32 # flips between 0 and 32 for double buffering
+offset = 0 # flips between 0 and 32 for double buffering
 
 # While loop has bulk of the code in it!
 

--- a/python-examples/OLEDclock.py
+++ b/python-examples/OLEDclock.py
@@ -22,6 +22,7 @@ spi_device = 0
 gpio = gaugette.gpio.GPIO()
 spi = gaugette.spi.SPI(spi_bus, spi_device)
 
+# Very important... This lets py-gaugette 'know' what pins to use in order to reset the display
 led = gaugette.ssd1306.SSD1306(gpio, spi, reset_pin=RESET_PIN, dc_pin=DC_PIN, rows=32, cols=128) # Change rows & cols values depending on your display dimensions.
 led.begin()
 led.clear_display()

--- a/python-examples/OLEDclock.py
+++ b/python-examples/OLEDclock.py
@@ -7,19 +7,37 @@
 
 # Imports the necessary modules
 import gaugette.ssd1306
+import gaugette.platform
+import gaugette.gpio
 import time
 import sys
+
+ROWS = 32
 
 # Define which GPIO pins the reset (RST) and DC signals on the OLED display are connected to on the
 # Raspberry Pi. The defined pin numbers must use the WiringPi pin numbering scheme.
 RESET_PIN = 15 # WiringPi pin 15 is GPIO14.
 DC_PIN = 16 # WiringPi pin 16 is GPIO15.
 
-led = gaugette.ssd1306.SSD1306(reset_pin=RESET_PIN, dc_pin=DC_PIN)
-led.begin()
-led.clear_display()
+spi_bus = 0
+spi_device = 0
+gpio = gaugette.gpio.GPIO()
+spi = gaugette.spi.SPI(spi_bus, spi_device)
 
-offset = 0 # flips between 0 and 32 for double buffering
+print("init")
+led = gaugette.ssd1306.SSD1306(gpio, spi, reset_pin=RESET_PIN, dc_pin=DC_PIN, rows=ROWS, cols=128)
+print("begin")
+led.begin()
+print("clear")
+led.clear_display()
+led.display()
+
+led.invert_display()
+time.sleep(0.5)
+led.normal_display()
+time.sleep(0.5)
+
+offset = 32 # flips between 0 and 32 for double buffering
 
 # While loop has bulk of the code in it!
 


### PR DESCRIPTION
Update OLEDclock.py so it would suite the updated (py-gaugette).
P.S. am not sure why but after I installed OLED (sh OLEDinstall.sh) and tried one of the *.py files, the first issue was that it missed the wiringPi module, so I used "sudo apt-get install python-dev python-pip" then "sudo pip install wiringpi" and then I could run the .py files. So maybe adjusting (sh OLEDinstall.sh) is also needed, am not sure, you are the expert here, I guess you know better!
Welll, it's working now thanks to your help!